### PR TITLE
Change ToLowerInvariant as ToLower

### DIFF
--- a/DynamicQueryBuilder.UnitTests/ExpressionBuilderTests/ApplyFiltersTests.cs
+++ b/DynamicQueryBuilder.UnitTests/ExpressionBuilderTests/ApplyFiltersTests.cs
@@ -121,7 +121,7 @@ namespace DynamicQueryBuilder.UnitTests.ExpressionBuilderTests
 
             IQueryable<TestModel> returnedSet = currentSet.ApplyFilters(filters).AsQueryable();
             string paramName = nameof(TestModel).ToLower();
-            string expectedQuery = $"{paramName} => (({paramName}.Age == 10) AndAlso {paramName}.Name.ToLowerInvariant().StartsWith(\"testone\".ToLowerInvariant()))";
+            string expectedQuery = $"{paramName} => (({paramName}.Age == 10) AndAlso {paramName}.Name.ToLower().StartsWith(\"testone\".ToLower()))";
             var expressionMethodCall = returnedSet.Expression as MethodCallExpression;
             Assert.NotNull(expressionMethodCall);
 

--- a/DynamicQueryBuilder.UnitTests/ExpressionBuilderTests/BuildFilterExpressionTests.cs
+++ b/DynamicQueryBuilder.UnitTests/ExpressionBuilderTests/BuildFilterExpressionTests.cs
@@ -35,7 +35,7 @@ namespace DynamicQueryBuilder.UnitTests.ExpressionBuilderTests
 
         [Theory]
         [InlineData("(((x.Name == \"Te\") Or (x.Name == \" Test\")) Or (x.Name == \" Testx\"))", true)]
-        [InlineData("(((x.Name.ToLowerInvariant() == \"te\".ToLowerInvariant()) Or (x.Name.ToLowerInvariant() == \" test\".ToLowerInvariant())) Or (x.Name.ToLowerInvariant() == \" testx\".ToLowerInvariant()))", false)]
+        [InlineData("(((x.Name.ToLower() == \"te\".ToLower()) Or (x.Name.ToLower() == \" test\".ToLower())) Or (x.Name.ToLower() == \" testx\".ToLower()))", false)]
         public void ShouldConvertInOperationToMultipleEquals(string expectedResultOfQuery, bool caseSensitive)
         {
             Expression result = ExpressionBuilder.BuildFilterExpression(

--- a/DynamicQueryBuilder.UnitTests/TestData/FilterTestData.cs
+++ b/DynamicQueryBuilder.UnitTests/TestData/FilterTestData.cs
@@ -13,7 +13,7 @@ namespace DynamicQueryBuilder.UnitTests.TestData
                 // Equals
                 // For checking strings
                 yield return new object[] { "(x.Name == \"Test\")", FilterOperation.Equals, true, "Test", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant() == \"test\".ToLowerInvariant())", FilterOperation.Equals, false, "Test", "Name" };
+                yield return new object[] { "(x.Name.ToLower() == \"test\".ToLower())", FilterOperation.Equals, false, "Test", "Name" };
 
                 // For other types
                 yield return new object[] { "(x.InnerMember.Age == 3)", FilterOperation.Equals, true, "3", "InnerMember.Age" };
@@ -21,12 +21,12 @@ namespace DynamicQueryBuilder.UnitTests.TestData
 
                 // Contains
                 yield return new object[] { "x.Name.Contains(\"Test\")", FilterOperation.Contains, true, "Test", "Name" };
-                yield return new object[] { "x.Name.ToLowerInvariant().Contains(\"test\".ToLowerInvariant())", FilterOperation.Contains, false, "Test", "Name" };
+                yield return new object[] { "x.Name.ToLower().Contains(\"test\".ToLower())", FilterOperation.Contains, false, "Test", "Name" };
 
                 // NotEquals
                 // For checking strings
                 yield return new object[] { "(x.Name != \"Test\")", FilterOperation.NotEqual, true, "Test", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant() != \"test\".ToLowerInvariant())", FilterOperation.NotEqual, false, "Test", "Name" };
+                yield return new object[] { "(x.Name.ToLower() != \"test\".ToLower())", FilterOperation.NotEqual, false, "Test", "Name" };
 
                 // For other types
                 yield return new object[] { "(x.InnerMember.Age != 3)", FilterOperation.NotEqual, true, "3", "InnerMember.Age" };
@@ -34,11 +34,11 @@ namespace DynamicQueryBuilder.UnitTests.TestData
 
                 // EndsWith
                 yield return new object[] { "x.Name.EndsWith(\"Test\")", FilterOperation.EndsWith, true, "Test", "Name" };
-                yield return new object[] { "x.Name.ToLowerInvariant().EndsWith(\"test\".ToLowerInvariant())", FilterOperation.EndsWith, false, "Test", "Name" };
+                yield return new object[] { "x.Name.ToLower().EndsWith(\"test\".ToLower())", FilterOperation.EndsWith, false, "Test", "Name" };
 
                 // StartsWith
                 yield return new object[] { "x.Name.StartsWith(\"Test\")", FilterOperation.StartsWith, true, "Test", "Name" };
-                yield return new object[] { "x.Name.ToLowerInvariant().StartsWith(\"test\".ToLowerInvariant())", FilterOperation.StartsWith, false, "Test", "Name" };
+                yield return new object[] { "x.Name.ToLower().StartsWith(\"test\".ToLower())", FilterOperation.StartsWith, false, "Test", "Name" };
 
                 // GreaterThan
                 // For Non-string types
@@ -46,7 +46,7 @@ namespace DynamicQueryBuilder.UnitTests.TestData
                 yield return new object[] { "(x.InnerMember.Age > 3)", FilterOperation.GreaterThan, false, "3", "InnerMember.Age" };
                 //For strings
                 yield return new object[] { "(x.Name.CompareTo(\"TestSix\") > 0)", FilterOperation.GreaterThan, true, "TestSix", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant().CompareTo(\"testsix\".ToLowerInvariant()) > 0)", FilterOperation.GreaterThan, false, "TestSix", "Name" };
+                yield return new object[] { "(x.Name.ToLower().CompareTo(\"testsix\".ToLower()) > 0)", FilterOperation.GreaterThan, false, "TestSix", "Name" };
 
                 // GreaterThanOrEqual
                 // For Non-string types
@@ -54,7 +54,7 @@ namespace DynamicQueryBuilder.UnitTests.TestData
                 yield return new object[] { "(x.InnerMember.Age >= 3)", FilterOperation.GreaterThanOrEqual, false, "3", "InnerMember.Age" };
                 //For strings
                 yield return new object[] { "(x.Name.CompareTo(\"TestSix\") >= 0)", FilterOperation.GreaterThanOrEqual, true, "TestSix", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant().CompareTo(\"testsix\".ToLowerInvariant()) >= 0)", FilterOperation.GreaterThanOrEqual, false, "TestSix", "Name" };
+                yield return new object[] { "(x.Name.ToLower().CompareTo(\"testsix\".ToLower()) >= 0)", FilterOperation.GreaterThanOrEqual, false, "TestSix", "Name" };
 
                 // LessThan
                 // For Non-string types
@@ -62,7 +62,7 @@ namespace DynamicQueryBuilder.UnitTests.TestData
                 yield return new object[] { "(x.InnerMember.Age < 3)", FilterOperation.LessThan, false, "3", "InnerMember.Age" };
                 //For strings
                 yield return new object[] { "(x.Name.CompareTo(\"TestSix\") < 0)", FilterOperation.LessThan, true, "TestSix", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant().CompareTo(\"testsix\".ToLowerInvariant()) < 0)", FilterOperation.LessThan, false, "TestSix", "Name" };
+                yield return new object[] { "(x.Name.ToLower().CompareTo(\"testsix\".ToLower()) < 0)", FilterOperation.LessThan, false, "TestSix", "Name" };
 
                 // LessThanOrEqual
                 // For Non-string types
@@ -70,7 +70,7 @@ namespace DynamicQueryBuilder.UnitTests.TestData
                 yield return new object[] { "(x.InnerMember.Age <= 3)", FilterOperation.LessThanOrEqual, false, "3", "InnerMember.Age" };
                 //For strings
                 yield return new object[] { "(x.Name.CompareTo(\"TestSix\") <= 0)", FilterOperation.LessThanOrEqual, true, "TestSix", "Name" };
-                yield return new object[] { "(x.Name.ToLowerInvariant().CompareTo(\"testsix\".ToLowerInvariant()) <= 0)", FilterOperation.LessThanOrEqual, false, "TestSix", "Name" };
+                yield return new object[] { "(x.Name.ToLower().CompareTo(\"testsix\".ToLower()) <= 0)", FilterOperation.LessThanOrEqual, false, "TestSix", "Name" };
             }
         }
     }

--- a/DynamicQueryBuilder/DynamicQueryBuilder.csproj
+++ b/DynamicQueryBuilder/DynamicQueryBuilder.csproj
@@ -15,9 +15,9 @@
     <SignAssembly>false</SignAssembly>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>1.0.3</Version>
-    <AssemblyVersion>1.0.0.3</AssemblyVersion>
-    <FileVersion>1.0.0.3</FileVersion>
+    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.0.4</AssemblyVersion>
+    <FileVersion>1.0.0.4</FileVersion>
     <PackageReleaseNotes>Enable dataset null search operations</PackageReleaseNotes>
     <PackageLicenseExpression></PackageLicenseExpression>
   </PropertyGroup>

--- a/DynamicQueryBuilder/ExpressionBuilder.cs
+++ b/DynamicQueryBuilder/ExpressionBuilder.cs
@@ -62,8 +62,8 @@ namespace DynamicQueryBuilder
 
         private static readonly MethodInfo _stringStartsWithMethod = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
 
-        private static readonly MethodInfo _toLowerInvariantMethod = typeof(string).GetMethod("ToLowerInvariant");
-
+        private static readonly MethodInfo _toLowerMethod = typeof(string).GetMethod("ToLower", Array.Empty<Type>());
+        
         private static readonly MethodInfo _compareTo = typeof(string).GetMethod("CompareTo", new[] { typeof(string) });
         #endregion
 
@@ -284,8 +284,8 @@ namespace DynamicQueryBuilder
                     sortOptions,
                     offsetOptions,
                     countOptions,
-                    opShortCodes ?? DefaultOpShortCodes,
-                    innerQueryOptions);
+                    opShortCodes: opShortCodes ?? DefaultOpShortCodes,
+                    memberQueryOptions: innerQueryOptions);
 
                 return dynamicQueryOptions;
             }
@@ -478,7 +478,7 @@ namespace DynamicQueryBuilder
                 && !filter.CaseSensitive
                 && usesCaseInsensitiveSource)
             {
-                parentMember = Expression.Call(parentMember, _toLowerInvariantMethod);
+                parentMember = Expression.Call(parentMember, _toLowerMethod);
             }
 
             // We are handling In operations seperately which are basically a list of OR=EQUALS operation. We recursively handle this operation.
@@ -539,7 +539,7 @@ namespace DynamicQueryBuilder
             {
                 constant = usesCaseInsensitiveSource
                     && !filter.CaseSensitive
-                    ? Expression.Call(constant, _toLowerInvariantMethod)
+                    ? Expression.Call(constant, _toLowerMethod)
                     : constant;
 
                 compareToExpression = Expression.Call(parentMember, _compareTo, constant);


### PR DESCRIPTION
Changed ToLowerInvariant method info as ToLower. EF Core cannot translate queries with ToLowerInvariant method. Maybe we can change constant values to lower before adding constant expressions.